### PR TITLE
allow proxy claims

### DIFF
--- a/contracts/HyperVIBES.sol
+++ b/contracts/HyperVIBES.sol
@@ -43,9 +43,6 @@ struct RealmConstraints {
     // min amount allowed for a single infusion
     uint256 minInfusionAmount;
 
-    // max amount allowed for a single infusion
-    uint256 maxInfusionAmount;
-
     // token cannot have a total infused balance greater than `maxTokenBalance`
     uint256 maxTokenBalance;
 
@@ -259,8 +256,6 @@ contract HyperVIBES {
 
     // check for constraint values that are nonsensical, revert if a problem
     function _validateRealmConstraints(RealmConstraints memory constraints) internal pure {
-        require(constraints.minInfusionAmount <= constraints.maxInfusionAmount, "invalid min/max amount");
-        require(constraints.maxInfusionAmount > 0, "invalid max amount");
         require(constraints.maxTokenBalance > 0, "invalid max token balance");
         require(constraints.minClaimAmount <= constraints.maxTokenBalance, "invalid min claim amount");
     }
@@ -344,7 +339,6 @@ contract HyperVIBES {
         // jit assert that this amount is valid within constraints
         require(amountToTransfer > 0, "nothing to transfer");
         require(amountToTransfer >= realm.constraints.minInfusionAmount, "amount too low");
-        require(amountToTransfer <= realm.constraints.maxInfusionAmount, "amount too high");
 
         // pull tokens from msg sender into the contract, executing transferFrom
         // last to ensure no malicious erc-20 can cause re-entrancy issues

--- a/contracts/HyperVIBES.sol
+++ b/contracts/HyperVIBES.sol
@@ -15,10 +15,32 @@ pragma solidity ^0.8.0;
     The possibilities are endless in the realms of your imagination.
     What would you do with that power?
 
-
                             Dreamt up & built at
                                 Rarible DAO
 
+                                  * * * *
+
+    HyperVIBES is a public and free protocol from Rarible DAO that lets you
+    infuse any ERC-20 token into ERC-721 NFTs from any minting platform.
+
+    Infused tokens can be mined and claimed by the NFT owner over time.
+
+    Create a fully isolated and independently configured HyperVIBES realm to run
+    your own experiments or protocols without having to deploy a smart contract.
+
+    HyperVIBES is:
+    - 🎁 Open Source
+    - 🥳 Massively Multiplayer
+    - 🌈 Public Infrastructure
+    - 🚀 Unstoppable and Censor-Proof
+    - 🌎 Multi-chain
+    - 💖 Free Forever
+
+    Feel free to use HyperVIBES in any way you want.
+
+    https://hypervibes.xyz
+    https://app.hypervibes.xyz
+    https://docs.hypervibes.xyz
 
 */
 

--- a/contracts/IHyperVIBES.sol
+++ b/contracts/IHyperVIBES.sol
@@ -1,0 +1,210 @@
+//SPDX-License-Identifier: Unlicense
+pragma solidity ^0.8.0;
+
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/token/ERC721/IERC721.sol";
+
+// data stored for-each infused token
+struct TokenData {
+    // total staked tokens for this NFT
+    uint256 balance;
+
+    // timestamp of last executed claim, determines claimable tokens
+    uint256 lastClaimAt;
+}
+
+// per-realm configuration
+struct RealmConfig {
+    // ERC-20 for the realm
+    IERC20 token;
+
+    // daily token mining rate -- constant for the entire realm
+    uint256 dailyRate;
+
+    // configured constraints for the realm
+    RealmConstraints constraints;
+}
+
+// constraint parameters for a realm
+struct RealmConstraints {
+    // An NFT must be infused with at least this amount of the token every time
+    // it's infused.
+    uint256 minInfusionAmount;
+
+    // An NFT's infused balance cannot exceed this amount. If an infusion would
+    // result in exceeding the max token balance, amount transferred is clamped
+    // to the max.
+    uint256 maxTokenBalance;
+
+    // When claiming mined tokens, at least this much must be claimed at a time.
+    uint256 minClaimAmount;
+
+    // If true, the infuser must own the NFT at time of infusion.
+    bool requireNftIsOwned;
+
+    // If true, an NFT can be infused more than once in the same realm.
+    bool allowMultiInfuse;
+
+    // If true, anybody with enough tokens may infuse an NFT. If false, they
+    // must be on the infusers list.
+    bool allowPublicInfusion;
+
+    // If true, anybody who owns an infused NFT may claim the mined tokens. If
+    // false, they must be on the claimers list
+    bool allowPublicClaiming;
+
+    // If true, NFTs from any ERC-721 contract can be infused. If false, the
+    // contract address must be on the collections list.
+    bool allowAllCollections;
+}
+
+// data provided when creating a realm
+struct CreateRealmInput {
+    // Display name for the realm. Does not have to be unique across HyperVIBES.
+    string name;
+
+    // Description for the realm.
+    string description;
+
+    // token, mining rate, an constraint data
+    RealmConfig config;
+
+    // Addresses that are allowed to add or remove admins, infusers, claimers,
+    // or collections to the realm.
+    address[] admins;
+
+    // Addresses that are allowed to infuse NFTs. Ignored if the allow public
+    // infusion constraint is true.
+    address[] infusers;
+
+    // Addresses that are allowed to claim mined tokens from an NFT. Ignored if
+    // the allow public claiming constraint is true.
+    address[] claimers;
+
+    // NFT contract addresses that can be infused. Ignore if the allow all
+    // collections constraint is true.
+    IERC721[] collections;
+}
+
+// data provided when modifying a realm -- constraints, token, etc are not
+// modifiable, but admins/infusers/claimers/collections can be added and removed
+// by an admin
+struct ModifyRealmInput {
+    uint256 realmId;
+    address[] adminsToAdd;
+    address[] adminsToRemove;
+    address[] infusersToAdd;
+    address[] infusersToRemove;
+    address[] claimersToAdd;
+    address[] claimersToRemove;
+    IERC721[] collectionsToAdd;
+    IERC721[] collectionsToRemove;
+}
+
+// data provided when infusing an nft
+struct InfuseInput {
+    uint256 realmId;
+
+    // NFT contract address
+    IERC721 collection;
+
+    // NFT token ID
+    uint256 tokenId;
+
+    // Infuser is manually specified, in the case of proxy infusions, msg.sender
+    // might not be the infuser. Proxy infusions require msg.sender to be an
+    // approved proxy by the credited infuser
+    address infuser;
+
+    // total amount of tokens to infuse. Actual infusion amount may be less
+    // based on maxTokenBalance realm constraint
+    uint256 amount;
+
+    // emitted with event
+    string comment;
+}
+
+// data provided when claiming from an infused nft
+struct ClaimInput {
+    uint256 realmId;
+
+    // NFT contract address
+    IERC721 collection;
+
+    // NFT token ID
+    uint256 tokenId;
+
+    // amount to claim. If this is greater than total claimable, only the max
+    // will be claimed (use a huge number here to "claim all" effectively)
+    uint256 amount;
+}
+
+interface IHyperVIBES {
+    event RealmCreated(uint256 indexed realmId, string name, string description);
+
+    event AdminAdded(uint256 indexed realmId, address indexed admin);
+
+    event AdminRemoved(uint256 indexed realmId, address indexed admin);
+
+    event InfuserAdded(uint256 indexed realmId, address indexed infuser);
+
+    event InfuserRemoved(uint256 indexed realmId, address indexed infuser);
+
+    event CollectionAdded(uint256 indexed realmId, IERC721 indexed collection);
+
+    event CollectionRemoved(uint256 indexed realmId, IERC721 indexed collection);
+
+    event ClaimerAdded(uint256 indexed realmId, address indexed claimer);
+
+    event ClaimerRemoved(uint256 indexed realmId, address indexed claimer);
+
+    event ProxyAdded(uint256 indexed realmId, address indexed proxy);
+
+    event ProxyRemoved(uint256 indexed realmId, address indexed proxy);
+
+    event Infused(
+        uint256 indexed realmId,
+        IERC721 indexed collection,
+        uint256 indexed tokenId,
+        address infuser,
+        uint256 amount,
+        string comment
+    );
+
+    event Claimed(
+        uint256 indexed realmId,
+        IERC721 indexed collection,
+        uint256 indexed tokenId,
+        uint256 amount
+    );
+
+    // setup a new realm
+    function createRealm(CreateRealmInput memory create) external;
+
+    // update admins, infusers, claimers, or collections for a realm
+    function modifyRealm(ModifyRealmInput memory input) external;
+
+    // infuse an nft
+    function infuse(InfuseInput memory input) external;
+
+    // allower operator to infuse or claim on behalf of msg.sender for a specific realm
+    function allowProxy(uint256 realmId, address proxy) external;
+
+    // deny operator the ability to infuse or claim on behalf of msg.sender for a specific realm
+    function denyProxy(uint256 realmId, address proxy) external;
+
+    // claim infused tokens
+    function claim(ClaimInput memory input) external;
+
+    // execute a batch of claims
+    function batchClaim(ClaimInput[] memory batch) external;
+
+    // execute a batch of infusions
+    function batchInfuse(InfuseInput[] memory batch) external;
+
+    // HyperVIBES
+    function name() external pure returns (string memory);
+
+    // total amount of mined tokens
+    function currentMinedTokens(uint256 realmId, IERC721 collection, uint256 tokenId) external view returns (uint256);
+}

--- a/test/HyperVIBES.spec.ts
+++ b/test/HyperVIBES.spec.ts
@@ -619,7 +619,20 @@ describe("HyperVIBES", function () {
       await hv.infuse({ ...infuse(), amount: parseUnits("10000") });
       await expect(
         hv.infuse({ ...infuse(), amount: parseUnits("10000") })
-      ).to.be.revertedWith("max token balance");
+      ).to.be.revertedWith("nothing to transfer");
+    });
+    it("should revert if clamped infusion amount is less than min infusion amount", async () => {
+      await token.mint(parseUnits("100000"));
+      await collection.mint("420");
+      const create = { ...createRealm(), infusers: [a0] };
+      create.config.constraints.maxTokenBalance = parseUnits("10000");
+      create.config.constraints.allowMultiInfuse = true;
+      create.config.constraints.minInfusionAmount = parseUnits("1000");
+      await hv.createRealm(create);
+      await hv.infuse({ ...infuse(), amount: parseUnits("9999") });
+      await expect(
+        hv.infuse({ ...infuse(), amount: parseUnits("10000") })
+      ).to.be.revertedWith("amount too low");
     });
   });
   describe("infusion proxy management", () => {

--- a/test/HyperVIBES.spec.ts
+++ b/test/HyperVIBES.spec.ts
@@ -41,7 +41,6 @@ describe("HyperVIBES", function () {
   const realmConstraints = () => {
     return {
       minInfusionAmount: parseUnits("0"),
-      maxInfusionAmount: parseUnits("100000"),
       maxTokenBalance: parseUnits("100000"),
       minClaimAmount: parseUnits("0"),
       requireNftIsOwned: true,
@@ -125,22 +124,6 @@ describe("HyperVIBES", function () {
       create.config.constraints.minClaimAmount = parseUnits("1001");
       await expect(hv.createRealm(create)).to.be.revertedWith(
         "invalid min claim amount"
-      );
-    });
-    it("should revert if min infusion amount exceeds max infusion amount", async () => {
-      const create = createRealm();
-      create.config.constraints.minInfusionAmount = BigNumber.from(500);
-      create.config.constraints.maxInfusionAmount = BigNumber.from(0);
-      await expect(hv.createRealm(create)).to.be.revertedWith(
-        "invalid min/max amount"
-      );
-    });
-    it("should revert if max infusion amount is zero", async () => {
-      const create = createRealm();
-      create.config.constraints.minInfusionAmount = BigNumber.from(0);
-      create.config.constraints.maxInfusionAmount = BigNumber.from(0);
-      await expect(hv.createRealm(create)).to.be.revertedWith(
-        "invalid max amount"
       );
     });
     it("should revert if max token balance is zero", async () => {
@@ -515,16 +498,6 @@ describe("HyperVIBES", function () {
       await expect(
         hv.infuse({ ...infuse(), realmId: "123" })
       ).to.be.revertedWith("invalid realm");
-    });
-    it("should revert if amount is too high", async () => {
-      await token.mint(parseUnits("100000"));
-      await collection.mint("420");
-      const create = { ...createRealm(), infusers: [a0] };
-      create.config.constraints.maxInfusionAmount = parseUnits("1000");
-      await hv.createRealm(create);
-      await expect(
-        hv.infuse({ ...infuse(), amount: parseUnits("10000") })
-      ).to.be.revertedWith("amount too high");
     });
     it("should revert if amount is too low", async () => {
       await token.mint(parseUnits("100000"));


### PR DESCRIPTION
we already had proxy infusions, where a given (realm, operator, infuser) tuple would be considered valid. This accommodates the use case of a frontend infusion contract infusing on behalf of another address

This PR generalizes the infusionProxy concept to simply "proxy", and allows authorized proxies to claim on behalf of a token owner. This accommodates the user case of a frontend claiming contract claiming on behalf of another address

Also adds a `allowPublicClaiming` constraint and list of `claimers`, works the same as for infusers


---

bunch more small things:
- remove max infusion amount
- ascii art / notes update
- comment updates
- move typedefs to `IHyperVIBES.sol`